### PR TITLE
prevent camera from looking straight up or down

### DIFF
--- a/PhotoMode/PhotoModeHud.cs
+++ b/PhotoMode/PhotoModeHud.cs
@@ -45,10 +45,10 @@ public class PhotoModeHud : MonoBehaviour {
 
       var textGo = new GameObject("PhotoModeHUD Popup Text");
       textGo.transform.SetParent(image.transform);
-      var text = textGo.AddComponent<Text>();
-      text.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
-      text.color = Color.white;
-      text.lineSpacing = 1.2f;
+      _popupTextComponent = textGo.AddComponent<Text>();
+      _popupTextComponent.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+      _popupTextComponent.color = Color.white;
+      _popupTextComponent.lineSpacing = 1.2f;
 
       _helpText = Instantiate(_popupText, _hud.transform);
       _helpText.name = "Help Text Background Image";
@@ -78,9 +78,8 @@ public class PhotoModeHud : MonoBehaviour {
          return;
       }
  
-      var text = _popupText.GetComponentInChildren<Text>();
-      text.text = message;
-      _hudTextFadeCoroutine = FadeTextToZeroAlpha(time , text);
+      _popupTextComponent.text = message;
+      _hudTextFadeCoroutine = FadeTextToZeroAlpha(time, _popupTextComponent);
       StartCoroutine(_hudTextFadeCoroutine);
    }
 	
@@ -129,6 +128,7 @@ public class PhotoModeHud : MonoBehaviour {
    }
 
    private GameObject _popupText;
+   private Text _popupTextComponent;
    private GameObject _helpText;
    private GameObject _hud;
    private PhotoModeSettings _settings;

--- a/PhotoMode/Plugin.cs
+++ b/PhotoMode/Plugin.cs
@@ -8,7 +8,7 @@ using UnityEngine.UI;
 
 namespace PhotoMode;
 
-[BepInPlugin("com.riskofresources.discohatesme.photomode", "PhotoMode", "3.0.7")]
+[BepInPlugin("com.riskofresources.discohatesme.photomode", "PhotoMode", "3.0.8")]
 [NetworkCompatibility(CompatibilityLevel.NoNeedForSync)]
 [BepInDependency("com.rune580.riskofoptions", BepInDependency.DependencyFlags.SoftDependency)]
 public class PhotoModePlugin : BaseUnityPlugin

--- a/PhotoMode/manifest.json
+++ b/PhotoMode/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "PhotoMode",
-  "version_number": "3.0.7",
+  "version_number": "3.0.8",
   "website_url": "",
   "description": "Photo Mode Redux. Installing Risk Of Options is highly recommended.",
   "dependencies": [


### PR DESCRIPTION
doesn't apply to smooth cam. fixes some issues with the previous implementation trying to set the euler angles directly which may not properly represent the current rotation w.r.t. a 0 degree rotation around the z-axis.