### PR TITLE
Dolly rotation control

### DIFF
--- a/PhotoMode/CameraControl.cs
+++ b/PhotoMode/CameraControl.cs
@@ -1,0 +1,45 @@
+using UnityEngine;
+
+namespace PhotoMode;
+
+public class CameraControl : MonoBehaviour, IPhotoModeUnityComponentSingleton {
+   private PhotoModeSettings _settings;
+   public bool IsSprinting { get; set; }
+   public bool IsSlowing { get; set; }
+   public static CameraControl Instance;
+
+   public void Init(PhotoModeSettings photoModeSettings) {
+      _settings = photoModeSettings;
+   }
+
+   public float GetCameraSpeed(float baseSpeed) {
+      if (IsSprinting) {
+         return baseSpeed * _settings.CameraSprintMultiplier.Value;
+      }
+
+      if (IsSlowing) {
+         return baseSpeed * _settings.CameraSlowMultiplier.Value;
+      }
+
+      return baseSpeed;
+   }
+
+   private void Awake() {
+      Instance = this;
+   }
+
+   private void Update() {
+      IsSprinting = Input.GetKey(_settings.CameraSprintKey.Value.MainKey);
+      IsSlowing = Input.GetKey(_settings.CameraSlowKey.Value.MainKey);
+ 
+      if (Input.GetKeyDown(_settings.ToggleSmoothCameraKey.Value.MainKey)) {
+         var newSmooth = !_settings.SmoothCamera.Value;
+         _settings.SmoothCamera.Value = newSmooth;
+         PhotoModeHud.Instance.DisplayAndFadeOutText($"Smooth Camera: {newSmooth}");
+      }
+   }
+
+   private void OnDestroy() {
+      Instance = null;
+   }
+}

--- a/PhotoMode/CameraStateUpdateMessage.cs
+++ b/PhotoMode/CameraStateUpdateMessage.cs
@@ -2,5 +2,10 @@ namespace PhotoMode;
 
 public struct CameraStateUpdateMessage {
    public PhotoModeCameraState CameraState;
-   public bool FromDolly;
+   public UpdatePriority Priority;
+}
+
+public enum UpdatePriority {
+   FreeLook,
+   Dolly,
 }

--- a/PhotoMode/CameraStateUpdateMessage.cs
+++ b/PhotoMode/CameraStateUpdateMessage.cs
@@ -1,0 +1,6 @@
+namespace PhotoMode;
+
+public struct CameraStateUpdateMessage {
+   public PhotoModeCameraState CameraState;
+   public bool FromDolly;
+}

--- a/PhotoMode/CameraUpdater.cs
+++ b/PhotoMode/CameraUpdater.cs
@@ -1,0 +1,75 @@
+using System;
+using RoR2;
+using UnityEngine;
+
+namespace PhotoMode;
+
+public class CameraUpdater : MonoBehaviour, ICameraStateProvider {
+   private static event EventHandler<PhotoModeCameraState> OnCameraStateUpdate; 
+   private PhotoModeCameraState _cameraState;
+   private bool _disableAllMovement;
+   private CameraRigController _cameraRigController;
+
+   public PhotoModeCameraState Init(CameraRigController cameraRigController, PhotoModeSettings settings) {
+      _cameraRigController = cameraRigController;
+      cameraRigController.SetOverrideCam(this, 0f);
+      cameraRigController.enableFading = false;
+      _disableAllMovement = settings.DisableAllMovement.Value;
+
+      return new PhotoModeCameraState {
+         position = cameraRigController.sceneCam.transform.position,
+         rotation = Quaternion.LookRotation(cameraRigController.sceneCam.transform.rotation * Vector3.forward),
+         fov = cameraRigController.sceneCam.fieldOfView
+      };
+   }
+ 
+   public static void UpdateCameraState(CameraStateUpdateMessage msg) {
+      OnCameraStateUpdate?.Invoke(null, msg.CameraState);
+   }
+
+   private void Awake() {
+      OnCameraStateUpdate += OnOnCameraStateUpdate;
+   }
+
+   private void OnOnCameraStateUpdate(object sender, PhotoModeCameraState e) {
+      _cameraState = e;
+   }
+
+   private void Update() {
+      if (!_cameraRigController?.sceneCam || _disableAllMovement) {
+         return;
+      }
+ 
+      _cameraRigController.sceneCam.transform.position = _cameraState.position;
+      _cameraRigController.sceneCam.transform.rotation = _cameraState.rotation;
+      _cameraRigController.sceneCam.fieldOfView = _cameraState.fov;
+   }
+
+   private void OnDestroy() {
+      OnCameraStateUpdate -= OnCameraStateUpdate;
+      _cameraRigController.enableFading = true;
+      _cameraRigController.SetOverrideCam(null);
+      var cameraTransform = _cameraRigController.sceneCam.transform;
+      cameraTransform.localPosition = Vector3.zero;
+      cameraTransform.localRotation = Quaternion.identity;
+   }
+ 
+   public void GetCameraState(CameraRigController _, ref CameraState cameraState)
+   {
+   }
+
+   public bool IsHudAllowed(CameraRigController _)
+   {
+      return false;
+   }
+
+   public bool IsUserControlAllowed(CameraRigController _)
+   {
+      return false;
+   }
+
+   public bool IsUserLookAllowed(CameraRigController _)
+   {
+      return false;
+   }
+}

--- a/PhotoMode/DollyService.cs
+++ b/PhotoMode/DollyService.cs
@@ -5,7 +5,9 @@ using UnityEngine;
 
 namespace PhotoMode;
 
-public class DollyService(bool smoothDolly, float camSpeed, Easing easing) {
+public class DollyService(bool smoothDolly, float dollyCamSpeed, Easing easing) {
+   private float CamSpeed => CameraControl.Instance.GetCameraSpeed(dollyCamSpeed);
+
    public IEnumerator DollyPlayback(List<PhotoModeCameraState> dollyStates) {
       var dollyIndex = 0;
       var linearCamera = dollyStates[0];
@@ -20,7 +22,7 @@ public class DollyService(bool smoothDolly, float camSpeed, Easing easing) {
             yield break;
          }
 
-         var distance = camSpeed * Time.unscaledDeltaTime;
+         var distance = CamSpeed * Time.unscaledDeltaTime;
          linearCamera.position = Vector3.MoveTowards(linearCamera.position, nextState.position, distance);
          var linearDistance = Vector3.Distance(linearCamera.position, nextState.position);
          var movePct = (totalDistance - linearDistance) / totalDistance;
@@ -33,7 +35,7 @@ public class DollyService(bool smoothDolly, float camSpeed, Easing easing) {
 
          CameraUpdater.UpdateCameraState(new CameraStateUpdateMessage {
             CameraState = currentState,
-            FromDolly = true
+            Priority = UpdatePriority.Dolly
          });
          yield return null;
       }
@@ -56,7 +58,7 @@ public class DollyService(bool smoothDolly, float camSpeed, Easing easing) {
             continue;
          }
 
-         var distance = camSpeed * Time.unscaledDeltaTime;
+         var distance = CamSpeed * Time.unscaledDeltaTime;
          linearCamera.position = Vector3.MoveTowards(linearCamera.position, nextState.position, distance);
          var linearDistance = Vector3.Distance(linearCamera.position, nextState.position);
          var movePct = (totalDistance - linearDistance) / totalDistance;
@@ -79,14 +81,14 @@ public class DollyService(bool smoothDolly, float camSpeed, Easing easing) {
 
          CameraUpdater.UpdateCameraState(new CameraStateUpdateMessage {
             CameraState = currentState,
-            FromDolly = true
+            Priority = UpdatePriority.Dolly
          });
          yield return null;
       }
    }
 
-   private float GetEasedRatio(float x, Easing easing) {
-      switch (easing) {
+   private float GetEasedRatio(float x, Easing e) {
+      switch (e) {
          case Easing.Linear:
             return x;
          case Easing.SineIn:

--- a/PhotoMode/DollyService.cs
+++ b/PhotoMode/DollyService.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace PhotoMode;
+
+public class DollyService(bool smoothDolly, float camSpeed, Easing easing) {
+   public IEnumerator DollyPlayback(List<PhotoModeCameraState> dollyStates) {
+      var dollyIndex = 0;
+      var linearCamera = dollyStates[0];
+
+      while (dollyIndex < dollyStates.Count - 1) {
+         var prevState = dollyStates[dollyIndex];
+         var nextState = dollyStates[dollyIndex + 1];
+         var totalDistance = Vector3.Distance(prevState.position, nextState.position);
+
+         // don't divide by 0
+         if (Mathf.Approximately(totalDistance, 0)) {
+            yield break;
+         }
+
+         var distance = camSpeed * Time.unscaledDeltaTime;
+         linearCamera.position = Vector3.MoveTowards(linearCamera.position, nextState.position, distance);
+         var linearDistance = Vector3.Distance(linearCamera.position, nextState.position);
+         var movePct = (totalDistance - linearDistance) / totalDistance;
+         var eased = GetEasedRatio(movePct, easing);
+         eased = Mathf.Clamp01(eased);
+         var currentState = PhotoModeCameraState.Lerp(ref prevState, ref nextState, eased);
+         if (Mathf.Approximately(linearDistance, 0)) {
+            dollyIndex++;
+         }
+
+         CameraUpdater.UpdateCameraState(new CameraStateUpdateMessage {
+            CameraState = currentState,
+            FromDolly = true
+         });
+         yield return null;
+      }
+   }
+
+   public IEnumerator MultiPointDollyPlayback(List<PhotoModeCameraState> positionCurve) {
+      List<PhotoModeCameraState> states = positionCurve;
+      var index = 0;
+      var linearCamera = states[0];
+
+      while (index < states.Count - 1) {
+         var prevState = states[index];
+         var nextState = states[index + 1];
+         var totalDistance = Vector3.Distance(prevState.position, nextState.position);
+
+         // don't divide by 0
+         if (Mathf.Approximately(totalDistance, 0)) {
+            Debug.Log(2 + index);
+            index++;
+            continue;
+         }
+
+         var distance = camSpeed * Time.unscaledDeltaTime;
+         linearCamera.position = Vector3.MoveTowards(linearCamera.position, nextState.position, distance);
+         var linearDistance = Vector3.Distance(linearCamera.position, nextState.position);
+         var movePct = (totalDistance - linearDistance) / totalDistance;
+         var currentState = PhotoModeCameraState.Lerp(ref prevState, ref nextState, movePct);
+
+         if (Mathf.Approximately(linearDistance, 0)) {
+            prevState = nextState;
+            index++;
+         }
+
+         // if we're not using a perfectly smooth dolly we can apply the easings to smooth out rotations
+         if (!smoothDolly) {
+            var (currentControlPoint, nextControlPoint) = prevState.ControlPoints;
+            var controlPointDistance = Vector3.Distance(currentControlPoint.position, nextControlPoint.position);
+            var controlPointPct = (controlPointDistance - Vector3.Distance(linearCamera.position, nextControlPoint.position)) / controlPointDistance;
+            var eased = GetEasedRatio(controlPointPct, easing);
+            eased = Mathf.Clamp01(eased);
+            currentState.rotation = Quaternion.Slerp(currentControlPoint.rotation, nextControlPoint.rotation, eased);
+         }
+
+         CameraUpdater.UpdateCameraState(new CameraStateUpdateMessage {
+            CameraState = currentState,
+            FromDolly = true
+         });
+         yield return null;
+      }
+   }
+
+   private float GetEasedRatio(float x, Easing easing) {
+      switch (easing) {
+         case Easing.Linear:
+            return x;
+         case Easing.SineIn:
+            return 1 - (float)Math.Cos(x * Math.PI / 2);
+         case Easing.EaseInOutSine:
+            return (float)(-(Math.Cos(Math.PI * x) - 1) / 2);
+         case Easing.EaseInOutCubic:
+            return (float)(x < 0.5 ? 4 * x * x * x : 1 - Math.Pow(-2 * x + 2, 3) / 2);
+         case Easing.EaseInOutQuad:
+            return (float)(x < 0.5 ? 2 * x * x : 1 - Math.Pow(-2 * x + 2, 2) / 2);
+         case Easing.SineOut:
+            return (float)Math.Sin(x * Math.PI / 2);
+         case Easing.QuadIn:
+            return x * x;
+         case Easing.QuadOut:
+            return 1 - (1 - x) * (1 - x);
+         case Easing.CubicIn:
+            return x * x * x;
+         case Easing.CubicOut:
+            return 1 - (1 - x) * (1 - x) * (1 - x);
+         case Easing.Reverse:
+            return 1 - x;
+         default:
+            Logger.Log("Invalid easing set, falling back to linear");
+            return x;
+      }
+   }
+}

--- a/PhotoMode/IPhotoModeUnityComponentSingleton.cs
+++ b/PhotoMode/IPhotoModeUnityComponentSingleton.cs
@@ -1,0 +1,6 @@
+namespace PhotoMode;
+
+// Marker for initialized component accessed as a singleton
+public interface IPhotoModeUnityComponentSingleton {
+   public void Init(PhotoModeSettings settings);
+}

--- a/PhotoMode/PhotoModeCameraState.cs
+++ b/PhotoMode/PhotoModeCameraState.cs
@@ -22,8 +22,7 @@ public struct PhotoModeCameraState {
    
     public static PhotoModeCameraState Lerp(ref PhotoModeCameraState a, ref PhotoModeCameraState b, float t)
     {
-      return new PhotoModeCameraState()
-      {
+      return new PhotoModeCameraState {
         position = Vector3.LerpUnclamped(a.position, b.position, t),
         rotation = Quaternion.SlerpUnclamped(a.rotation, b.rotation, t),
         fov = Mathf.LerpUnclamped(a.fov, b.fov, t),

--- a/PhotoMode/PhotoModeController.cs
+++ b/PhotoMode/PhotoModeController.cs
@@ -267,7 +267,11 @@ internal class PhotoModeController : MonoBehaviour {
       ConditionalNegate(ref upValue, userProfile.mouseLookInvertY);
       var up = Quaternion.AngleAxis(upValue, Vector3.left);
       var left = Quaternion.AngleAxis(leftValue, Vector3.up);
-      var val = new Vector3(inputPlayer.GetAxis(0) * _settings.CameraPanSpeed.Value, 0f, inputPlayer.GetAxis(1) * _settings.CameraPanSpeed.Value);
+      var val = new Vector3(
+         CameraControl.Instance.GetCameraSpeed(inputPlayer.GetAxis(0) * _settings.CameraPanSpeed.Value), 
+         0f,
+         CameraControl.Instance.GetCameraSpeed(inputPlayer.GetAxis(1) * _settings.CameraPanSpeed.Value)
+      );
 
       if (val.magnitude > 0) {
          _recordEndPosition = true;
@@ -280,17 +284,6 @@ internal class PhotoModeController : MonoBehaviour {
          val.y += _settings.CameraElevationSpeed.Value;
       }
 
-      var sprinting = Input.GetKey(_settings.CameraSprintKey.Value.MainKey);
-      var slowing = Input.GetKey(_settings.CameraSlowKey.Value.MainKey);
-      var sprintMultiplier = _settings.CameraSprintMultiplier.Value;
-      var slowMultiplier = _settings.CameraSlowMultiplier.Value;
-
-      if (sprinting) {
-         val *= sprintMultiplier;
-      }
-      else if (slowing) {
-         val *= slowMultiplier;
-      }
       var originalDirection = _cameraState.rotation;
       var withRollEuler = originalDirection.eulerAngles;
       var unrolled = left * Quaternion.Euler(withRollEuler.x, withRollEuler.y, 0) * up;

--- a/PhotoMode/PhotoModeHud.cs
+++ b/PhotoMode/PhotoModeHud.cs
@@ -5,7 +5,9 @@ using UnityEngine.UI;
 
 namespace PhotoMode;
 
-public class PhotoModeHud : MonoBehaviour {
+public class PhotoModeHud : MonoBehaviour, IPhotoModeUnityComponentSingleton {
+   public static PhotoModeHud Instance;
+ 
    public void Init(PhotoModeSettings settings) {
       _settings = settings;
       // hud (with canvas)
@@ -17,7 +19,7 @@ public class PhotoModeHud : MonoBehaviour {
       Canvas canvas = _hud.AddComponent<Canvas>();
       canvas.renderMode = RenderMode.ScreenSpaceOverlay;
       _hud.AddComponent<CanvasScaler>().scaleFactor = (float)CanvasScaler.ScaleMode.ScaleWithScreenSize;
-      
+ 
       // bottom left image
       _popupText = new GameObject("Popup Text Background Image");
       _popupText.transform.SetParent(_hud.transform);
@@ -96,22 +98,16 @@ public class PhotoModeHud : MonoBehaviour {
       _popupText.SetActive(false);
    }
 
-   private void Update() {
-      if (Input.GetKeyDown(_settings.DisplayHelpText.Value.MainKey)) {
-         ToggleHelpText();
-      }
-   }
-
    private void ToggleHelpText()
    {
       var text = _helpText.GetComponentInChildren<Text>();
 
-      string message = """
-                       Pan Camera: WASD
-                       Change Roll: M3 + Mouse X
-                       Change FOV: M2 + Mouse Y
-                       Change Focus Distance: Scroll Wheel
-                       """;
+      var message = """
+                    Pan Camera: WASD
+                    Change Roll: M3 + Mouse X
+                    Change FOV: M2 + Mouse Y
+                    Change Focus Distance: Scroll Wheel
+                    """;
       foreach (var setting in _settings.Settings) {
          if(setting is PhotoModeSetting<KeyboardShortcut> keySetting) {
             message += $"\n{keySetting.Name}: {keySetting.Value.MainKey.ToString()}";
@@ -123,8 +119,19 @@ public class PhotoModeHud : MonoBehaviour {
       _helpText.SetActive(!_helpText.activeInHierarchy);
    }
 
+   private void Awake() {
+      Instance = this;
+   }
+
+   private void Update() {
+      if (Input.GetKeyDown(_settings.DisplayHelpText.Value.MainKey)) {
+         ToggleHelpText();
+      }
+   }
+
    private void OnDestroy() {
       Destroy(_hud);
+      Instance = null;
    }
 
    private GameObject _popupText;

--- a/PhotoMode/PhotoModeSettings.cs
+++ b/PhotoMode/PhotoModeSettings.cs
@@ -23,104 +23,107 @@ public class PhotoModeSettings {
       Logger.Log("Creating new Photo Mode Settings");
       _configFile = configFile;
       BaseDir = baseDir;
-      // PresetName = CreatePhotoModeSetting(SettingCategory.General, "Preset Name", "Default", "Name of the preset.");
-      CameraSensitivity = CreatePhotoModeSetting(SettingCategory.General, "Camera Sensitivity", 1f, "Sensitivity of the camera movements.", 0);
-      CameraPanSpeed = CreatePhotoModeSetting(SettingCategory.General, "Camera Pan Speed", 5f, "Speed of the camera pan.", 0);
-      CameraElevationSpeed = CreatePhotoModeSetting(SettingCategory.General, "Camera Elevation Speed", 5f, "Speed of the camera raise/lower.", 0);
-      CameraRollSensitivity = CreatePhotoModeSetting(SettingCategory.General, "Camera Roll Sensitivity", 10f, "Sensitivity of the camera roll.", 0);
-      CameraFovSensitivity = CreatePhotoModeSetting(SettingCategory.General, "Camera FOV Sensitivity", 10f, "Sensitivity of the camera FOV speed.", 0);
-      CameraSprintMultiplier = CreatePhotoModeSetting(SettingCategory.General, "Camera Sprint Multiplier", 5f, "Multiplier for how much the camera increases in speed when held.", min: 1);
-      CameraSlowMultiplier = CreatePhotoModeSetting(SettingCategory.General, "Camera Slow Multiplier", 0.3f, "Multiplier for how much the camera decreases in speed when held.", max: 1);
-      SnapRollEnabled = CreatePhotoModeSetting(SettingCategory.General, "Snap Roll Enabled", true, "If the roll should snap back to 0 when close to 0 roll angle.");
-      CameraMinFov = CreatePhotoModeSetting(SettingCategory.General, "Camera Min FOV", 4f, "Minimum camera field of view.", min: 0, max: 180);
-      CameraMaxFov = CreatePhotoModeSetting(SettingCategory.General, "Camera Max FOV", 120f, "Maximum camera field of view.", min: 0, max: 180);
-      TimeScaleStep = CreatePhotoModeSetting(SettingCategory.General, "Time Scale Step", 0.1f, "Step value to increase/decrease time scale when key is pressed.", max: 10);
-		
-      SmoothCamera = CreatePhotoModeSetting(SettingCategory.General, "Smooth Camera", true, "Check to smooth the free-cam.");
-      PanningSmooth = CreatePhotoModeSetting(SettingCategory.General, "Camera Smooth Pan Speed", 50f, "How fast the smooth pan camera can move.", 0);
-      PanningSmoothTime = CreatePhotoModeSetting(SettingCategory.General, "Camera Panning Smoothing Time", 1.5f, "How many seconds to smooth the camera position while panning (inertia after releasing panning keys)", 0);
-      MaxSmoothRotationSpeed = CreatePhotoModeSetting(SettingCategory.General, "Smooth Rotation Max Speed", 5f, "How fast the smooth camera can rotate", 0);
-      RotationSmoothDecay = CreatePhotoModeSetting(SettingCategory.General, "Smooth Rotation Decay", 0.25f, "How much to decay the rotation speed after stopping mouse movement", 0);
-		
-      // dolly
-      DollyEasingFunction = CreatePhotoModeSetting(SettingCategory.General, "Dolly Easing Function", Easing.Linear, "How the dolly cam transitions between states. In means start slow and end fast, out means start fast and end slow.");
-      DollyCamSpeed = CreatePhotoModeSetting(SettingCategory.General, "Dolly Cam Speed", 5f, "Speed at which the dolly cam pans/rotates", 0);
-      DollyFollowRotation = CreatePhotoModeSetting(SettingCategory.General, "Dolly Follows Rotation", true, "If the dolly camera should follow the rotation you set at the checkpoints or only follow the path and let the user control the rotation.");
-      NumberOfDollyPoints = CreatePhotoModeSetting(SettingCategory.General, "Dolly Path Smoothing", 50, "How many line segments to break the dolly path into to create a smooth path. Only applies when you have at least 1 checkpoint. The more points you add the slower the dolly will move.", min: 2, max: 5000, increment: 1);
-      DollyFollowsFocus = CreatePhotoModeSetting(SettingCategory.General, "Dolly Auto-Focus", false, "If the dolly should follow your focus changes.");
-      SmoothDolly = CreatePhotoModeSetting(SettingCategory.General, "Smooth Dolly Cam", true, "If the dolly cam should always be smooth (when adding at least 1 checkpoint). " +
-         "This sounds good but it has a limitation: the dolly cam will always move/rotate smoothly but it will only rotate from the starting rotation to the final dolly end rotation regardless of any rotation set at each checkpoint. " +
-         "This means if you create a dolly path that rotates ~300 degrees the camera will likely rotate ~60 degrees to follow the shortest path to the final rotation. " +
-         "If you uncheck this the dolly will follow the rotation at each checkpoint but if your checkpoints aren't smoothly spaced your camera will look like it bounces at each checkpoint. " +
-         "More Info: The line that the dolly cam follows is always smooth but the rotation might make it look rough when disabling this setting because between checkpoint A and checkpoint B the dolly tries to " +
-         "hit the goal rotation when it reaches checkpoint B. If the distance between the points is 50 units, your difference in rotation is 50 degrees, and your dolly moves at 1 unit/second, the dolly will rotate at 1 degrees/second. " +
-         "Now if you set another point C with the same parameters and the distance from B to C is 100 units and your rotation from B to C is 50 degrees your dolly will rotate at 2 degrees/second. This will create a noticeable jolt at " +
-         "the checkpoint as your dolly rotation instantly speeds up. If instead you properly space your dolly checkpoints so that the rotations are congruent to the distance between checkpoints it's a better option to leave this disabled.");
-		
-      // key bindings
-      RaiseCameraKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Raise Camera", new KeyboardShortcut(KeyCode.E));
-      LowerCameraKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Lower Camera", new KeyboardShortcut(KeyCode.Q));
-      CameraSprintKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Speed Up Camera", new KeyboardShortcut(KeyCode.LeftControl));
-      CameraSlowKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Slow Down Camera", new KeyboardShortcut(KeyCode.LeftShift));
-      ArcCameraKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Arc Camera On Player", new KeyboardShortcut(KeyCode.Space));
-      ToggleRecordingKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Toggle Recording Key", new KeyboardShortcut(KeyCode.R));
-      DollyPlaybackKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Dolly Playback Key", new KeyboardShortcut(KeyCode.P));
-      DollyCheckpointKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Add Dolly Checkpoint", new KeyboardShortcut(KeyCode.T));
-      IncreaseTimeScaleKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Increase Time Scale", new KeyboardShortcut(KeyCode.PageUp));
-      DecreaseTimeScaleKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Decrease Time Scale", new KeyboardShortcut(KeyCode.PageDown));
-      ToggleTimePausedKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Toggle Pause Key", new KeyboardShortcut(KeyCode.Pause));
-      ToggleSmoothCameraKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Toggle Smooth Camera", new KeyboardShortcut(KeyCode.G));
-      NextPlayerKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Arc Focus Previous Player", new KeyboardShortcut(KeyCode.LeftArrow));
-      PrevPlayerKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Arc Focus Next Player", new KeyboardShortcut(KeyCode.RightArrow));
-      // CaptureScreen = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Capture Screen", new KeyboardShortcut(KeyCode.None), "Records RAW textures to PNGs and saves into your Risk of Rain 2 data folder. Huge file size since it captures at 4x resolution and at your current frame rate. Limit the frame rate or change resolution to adjust.");
-      SaveReplayBuffer = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Save Replay Buffer", new KeyboardShortcut(KeyCode.F9), "Save the current replay buffer as an image sequence to disk in your risk of rain 2 data/recordings folder.");
-      DisplayHelpText = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Display Help Text", new KeyboardShortcut(KeyCode.H));
- 
-      // arc settings
-      ToggleArcCamera = CreatePhotoModeSetting(SettingCategory.ArcCamera, "Toggle Arc Camera", false, "True to toggle arc camera on keypress instead of needing to hold the button.");
-      SmoothArcCamera = CreatePhotoModeSetting(SettingCategory.ArcCamera, "Smooth Arc", true, "Smoothly rotate/pan around the player instead of snapping");
-      ArcPanningSmoothTime = CreatePhotoModeSetting(SettingCategory.ArcCamera, "Arc Panning Smooth Time", 1f, "How many seconds to smooth the camera position when the target of an arc camera moves", 0);
-      SmoothArcCamSpeed = CreatePhotoModeSetting(SettingCategory.ArcCamera, "Smooth Arc Camera Speed", 5f, "Amount of smoothing for the arc camera", 0);
-      RestrictArcPlayers = CreatePhotoModeSetting(SettingCategory.ArcCamera, "Arc Around Players Only", true, "Whether to arc around players or any model in the scene");
-
-      // post processing
-      PostProcessing = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Enable Post Processing", true, "Enable post processing effects");
-      PostProcessingAntiAliasing = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Anti-aliasing", true, "Enable anti-aliasing");
-      PostProcessDepth = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Depth of Field", true, "Enable depth of field");
-      PostProcessFocusDistance = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Focus Distance", 3.2f, "Distance to the point of focus. Adjustable on the fly with the scroll wheel", min: 0, max: 1000);
-      PostProcessFocalLength = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Focal Length", 50f, "Set the distance between the lens and the film. The larger the value is, the shallower the depth of field is.", min: 1, max: 300);
-      PostProcessAperture = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Aperture", 5.6f, "Set the ratio of the aperture (known as f-stop or f-number). The smaller the value is, the shallower the depth of field is.", max: 64);
-      PostProcessingFocusDistanceStep = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Focus Distance Step", 0.1f, "Step value to increase/decrease depth of field focus distance as you scroll", 0.01f);
-      PostProcessVignette = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Vignette", false, "Enable Vignette");
-
       try {
-         PostProcessVignetteColor = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Vignette Color", Color.black, "Vignette Color");
-      }
-      catch (Exception _) {
-         // TODO ignore errors for new because of serialization issues running outside unity
-         // Logger.Log($"Color doesn't serialize: {e}");
-      }
+         // PresetName = CreatePhotoModeSetting(SettingCategory.General, "Preset Name", "Default", "Name of the preset.");
+         CameraSensitivity = CreatePhotoModeSetting(SettingCategory.General, "Camera Sensitivity", 1f, "Sensitivity of the camera movements.", 0);
+         CameraPanSpeed = CreatePhotoModeSetting(SettingCategory.General, "Camera Pan Speed", 5f, "Speed of the camera pan.", 0);
+         CameraElevationSpeed = CreatePhotoModeSetting(SettingCategory.General, "Camera Elevation Speed", 5f, "Speed of the camera raise/lower.", 0);
+         CameraRollSensitivity = CreatePhotoModeSetting(SettingCategory.General, "Camera Roll Sensitivity", 10f, "Sensitivity of the camera roll.", 0);
+         CameraFovSensitivity = CreatePhotoModeSetting(SettingCategory.General, "Camera FOV Sensitivity", 10f, "Sensitivity of the camera FOV speed.", 0);
+         CameraSprintMultiplier = CreatePhotoModeSetting(SettingCategory.General, "Camera Sprint Multiplier", 5f, "Multiplier for how much the camera increases in speed when held.", min: 1);
+         CameraSlowMultiplier = CreatePhotoModeSetting(SettingCategory.General, "Camera Slow Multiplier", 0.3f, "Multiplier for how much the camera decreases in speed when held.", max: 1);
+         SnapRollEnabled = CreatePhotoModeSetting(SettingCategory.General, "Snap Roll Enabled", true, "If the roll should snap back to 0 when close to 0 roll angle.");
+         CameraMinFov = CreatePhotoModeSetting(SettingCategory.General, "Camera Min FOV", 4f, "Minimum camera field of view.", min: 0, max: 180);
+         CameraMaxFov = CreatePhotoModeSetting(SettingCategory.General, "Camera Max FOV", 120f, "Maximum camera field of view.", min: 0, max: 180);
+         TimeScaleStep = CreatePhotoModeSetting(SettingCategory.General, "Time Scale Step", 0.1f, "Step value to increase/decrease time scale when key is pressed.", max: 10);
+         
+         SmoothCamera = CreatePhotoModeSetting(SettingCategory.General, "Smooth Camera", true, "Check to smooth the free-cam.");
+         PanningSmooth = CreatePhotoModeSetting(SettingCategory.General, "Camera Smooth Pan Speed", 50f, "How fast the smooth pan camera can move.", 0);
+         PanningSmoothTime = CreatePhotoModeSetting(SettingCategory.General, "Camera Panning Smoothing Time", 1.5f, "How many seconds to smooth the camera position while panning (inertia after releasing panning keys)", 0);
+         MaxSmoothRotationSpeed = CreatePhotoModeSetting(SettingCategory.General, "Smooth Rotation Max Speed", 5f, "How fast the smooth camera can rotate", 0);
+         RotationSmoothDecay = CreatePhotoModeSetting(SettingCategory.General, "Smooth Rotation Decay", 0.25f, "How much to decay the rotation speed after stopping mouse movement", 0);
+         
+         // dolly
+         DollyEasingFunction = CreatePhotoModeSetting(SettingCategory.General, "Dolly Easing Function", Easing.Linear, "How the dolly cam transitions between states. In means start slow and end fast, out means start fast and end slow.");
+         DollyCamSpeed = CreatePhotoModeSetting(SettingCategory.General, "Dolly Cam Speed", 5f, "Speed at which the dolly cam pans/rotates", 0);
+         DollyFollowRotation = CreatePhotoModeSetting(SettingCategory.General, "Dolly Follows Rotation", true, "If the dolly camera should follow the rotation you set at the checkpoints or only follow the path and let the user control the rotation.");
+         NumberOfDollyPoints = CreatePhotoModeSetting(SettingCategory.General, "Dolly Path Smoothing", 50, "How many line segments to break the dolly path into to create a smooth path. Only applies when you have at least 1 checkpoint. The more points you add the slower the dolly will move.", min: 2, max: 5000, increment: 1);
+         DollyFollowsFocus = CreatePhotoModeSetting(SettingCategory.General, "Dolly Auto-Focus", false, "If the dolly should follow your focus changes.");
+         SmoothDolly = CreatePhotoModeSetting(SettingCategory.General, "Smooth Dolly Cam", true, "If the dolly cam should always be smooth (when adding at least 1 checkpoint). " +
+            "This sounds good but it has a limitation: the dolly cam will always move/rotate smoothly but it will only rotate from the starting rotation to the final dolly end rotation regardless of any rotation set at each checkpoint. " +
+            "This means if you create a dolly path that rotates ~300 degrees the camera will likely rotate ~60 degrees to follow the shortest path to the final rotation. " +
+            "If you uncheck this the dolly will follow the rotation at each checkpoint but if your checkpoints aren't smoothly spaced your camera will look like it bounces at each checkpoint. " +
+            "More Info: The line that the dolly cam follows is always smooth but the rotation might make it look rough when disabling this setting because between checkpoint A and checkpoint B the dolly tries to " +
+            "hit the goal rotation when it reaches checkpoint B. If the distance between the points is 50 units, your difference in rotation is 50 degrees, and your dolly moves at 1 unit/second, the dolly will rotate at 1 degrees/second. " +
+            "Now if you set another point C with the same parameters and the distance from B to C is 100 units and your rotation from B to C is 50 degrees your dolly will rotate at 2 degrees/second. This will create a noticeable jolt at " +
+            "the checkpoint as your dolly rotation instantly speeds up. If instead you properly space your dolly checkpoints so that the rotations are congruent to the distance between checkpoints it's a better option to leave this disabled.");
+         
+         // key bindings
+         RaiseCameraKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Raise Camera", new KeyboardShortcut(KeyCode.E));
+         LowerCameraKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Lower Camera", new KeyboardShortcut(KeyCode.Q));
+         CameraSprintKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Speed Up Camera", new KeyboardShortcut(KeyCode.LeftControl));
+         CameraSlowKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Slow Down Camera", new KeyboardShortcut(KeyCode.LeftShift));
+         ArcCameraKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Arc Camera On Player", new KeyboardShortcut(KeyCode.Space));
+         ToggleRecordingKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Toggle Recording Key", new KeyboardShortcut(KeyCode.R));
+         DollyPlaybackKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Dolly Playback Key", new KeyboardShortcut(KeyCode.P));
+         DollyCheckpointKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Add Dolly Checkpoint", new KeyboardShortcut(KeyCode.T));
+         IncreaseTimeScaleKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Increase Time Scale", new KeyboardShortcut(KeyCode.PageUp));
+         DecreaseTimeScaleKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Decrease Time Scale", new KeyboardShortcut(KeyCode.PageDown));
+         ToggleTimePausedKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Toggle Pause Key", new KeyboardShortcut(KeyCode.Pause));
+         ToggleSmoothCameraKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Toggle Smooth Camera", new KeyboardShortcut(KeyCode.G));
+         NextPlayerKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Arc Focus Previous Player", new KeyboardShortcut(KeyCode.LeftArrow));
+         PrevPlayerKey = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Arc Focus Next Player", new KeyboardShortcut(KeyCode.RightArrow));
+         // CaptureScreen = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Capture Screen", new KeyboardShortcut(KeyCode.None), "Records RAW textures to PNGs and saves into your Risk of Rain 2 data folder. Huge file size since it captures at 4x resolution and at your current frame rate. Limit the frame rate or change resolution to adjust.");
+         SaveReplayBuffer = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Save Replay Buffer", new KeyboardShortcut(KeyCode.F9), "Save the current replay buffer as an image sequence to disk in your risk of rain 2 data/recordings folder.");
+         DisplayHelpText = CreatePhotoModeSetting(SettingCategory.KeyBindings, "Display Help Text", new KeyboardShortcut(KeyCode.H));
+    
+         // arc settings
+         ToggleArcCamera = CreatePhotoModeSetting(SettingCategory.ArcCamera, "Toggle Arc Camera", false, "True to toggle arc camera on keypress instead of needing to hold the button.");
+         SmoothArcCamera = CreatePhotoModeSetting(SettingCategory.ArcCamera, "Smooth Arc", true, "Smoothly rotate/pan around the player instead of snapping");
+         ArcPanningSmoothTime = CreatePhotoModeSetting(SettingCategory.ArcCamera, "Arc Panning Smooth Time", 1f, "How many seconds to smooth the camera position when the target of an arc camera moves", 0);
+         SmoothArcCamSpeed = CreatePhotoModeSetting(SettingCategory.ArcCamera, "Smooth Arc Camera Speed", 5f, "Amount of smoothing for the arc camera", 0);
+         RestrictArcPlayers = CreatePhotoModeSetting(SettingCategory.ArcCamera, "Arc Around Players Only", true, "Whether to arc around players or any model in the scene");
 
-      PostProcessVignetteIntensity = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Vignette Intensity", .35f, "Set the amount of vignetting on screen.", 0, 1);
-      PostProcessVignetteSmoothness = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Vignette Smoothness", .5f, "Set the smoothness of the Vignette borders.", 0, 1);
-      PostProcessVignetteRoundness = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Vignette Roundness", 1f, "Set the value to round the Vignette. Lower values will make a more squared vignette.", 0, 1);
-      PostProcessVignetteRounded = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Vignette Rounded", false, "Enable this checkbox to make the vignette perfectly round. When disabled, the Vignette effect is dependent on the current aspect ratio.");
-      BreakBeforeColorGrading = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Break Before Color Grading", false, "Stop applying post-process effects before color grading for exporting to external color grading");
-      PostProcessColorGrading = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Color Grading", false, "Enable LUT color grading (requires .cube LUT name specified)");
-      LutName = CreatePhotoModeSetting(SettingCategory.PostProcessing, "LUT Name", "", "The name of your .cube LUT to import (full name including .cube extension)");
-		
-      // other
-      TextFadeTime = CreatePhotoModeSetting(SettingCategory.UI, "Text Fade Out Time", 1.5f, "How long to show text before fading out", min: 0, increment: 0.1f);
-      ShowHelp = CreatePhotoModeSetting(SettingCategory.UI, "Show Help Dialog", true, "Show the help dialog when entering photo mode");
-      ShowDollyPath = CreatePhotoModeSetting(SettingCategory.UI, "Show Dolly Path", false, "Show the path of the dolly (mostly for debugging).");
-      
-      // experimental
-      DisableAllMovement = CreatePhotoModeSetting(SettingCategory.Experimental, "Disable All Camera Movement", false, "Disable movement for external control or testing.");
-      ExportLinearColorSpace = CreatePhotoModeSetting(SettingCategory.Experimental, "Record linear color space", false, "When recording a RAW screen-capture should the exported images use linear or sRGB color space.");
-      EnableReplayBuffer = CreatePhotoModeSetting(SettingCategory.Experimental, "Enable Replay buffer", false, "It's a replay buffer");
-      ReplayBufferDuration = CreatePhotoModeSetting(SettingCategory.Experimental, "Replay Buffer Duration", 1f, "Number of seconds to record.");
-      ReplayBufferFramerate = CreatePhotoModeSetting(SettingCategory.Experimental, "Replay Buffer Framerate", 60f, "Rate at which to save frames.", 1f, 240f, 1f);
-      ReplayBufferResolutionScale = CreatePhotoModeSetting(SettingCategory.Experimental, "Replay Buffer Resolution Scale", 1f, "The scaling for the screen size. ", 0.1f, 4f, 0.1f);
+         // post processing
+         PostProcessing = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Enable Post Processing", true, "Enable post processing effects");
+         PostProcessingAntiAliasing = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Anti-aliasing", true, "Enable anti-aliasing");
+         PostProcessDepth = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Depth of Field", true, "Enable depth of field");
+         PostProcessFocusDistance = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Focus Distance", 3.2f, "Distance to the point of focus. Adjustable on the fly with the scroll wheel", min: 0, max: 1000);
+         PostProcessFocalLength = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Focal Length", 50f, "Set the distance between the lens and the film. The larger the value is, the shallower the depth of field is.", min: 1, max: 300);
+         PostProcessAperture = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Aperture", 5.6f, "Set the ratio of the aperture (known as f-stop or f-number). The smaller the value is, the shallower the depth of field is.", max: 64);
+         PostProcessingFocusDistanceStep = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Focus Distance Step", 0.1f, "Step value to increase/decrease depth of field focus distance as you scroll", 0.01f);
+         PostProcessVignette = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Vignette", false, "Enable Vignette");
+         PostProcessVignetteColor = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Vignette Color", Color.black, "Vignette Color");
+
+         PostProcessVignetteIntensity = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Vignette Intensity", .35f, "Set the amount of vignetting on screen.", 0, 1);
+         PostProcessVignetteSmoothness = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Vignette Smoothness", .5f, "Set the smoothness of the Vignette borders.", 0, 1);
+         PostProcessVignetteRoundness = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Vignette Roundness", 1f, "Set the value to round the Vignette. Lower values will make a more squared vignette.", 0, 1);
+         PostProcessVignetteRounded = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Vignette Rounded", false, "Enable this checkbox to make the vignette perfectly round. When disabled, the Vignette effect is dependent on the current aspect ratio.");
+         BreakBeforeColorGrading = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Break Before Color Grading", false, "Stop applying post-process effects before color grading for exporting to external color grading");
+         PostProcessColorGrading = CreatePhotoModeSetting(SettingCategory.PostProcessing, "Color Grading", false, "Enable LUT color grading (requires .cube LUT name specified)");
+         LutName = CreatePhotoModeSetting(SettingCategory.PostProcessing, "LUT Name", "", "The name of your .cube LUT to import (full name including .cube extension)");
+         
+         // other
+         TextFadeTime = CreatePhotoModeSetting(SettingCategory.UI, "Text Fade Out Time", 1.5f, "How long to show text before fading out", min: 0, increment: 0.1f);
+         ShowHelp = CreatePhotoModeSetting(SettingCategory.UI, "Show Help Dialog", true, "Show the help dialog when entering photo mode");
+         ShowDollyPath = CreatePhotoModeSetting(SettingCategory.UI, "Show Dolly Path", false, "Show the path of the dolly (mostly for debugging).");
+         
+         // experimental
+         DisableAllMovement = CreatePhotoModeSetting(SettingCategory.Experimental, "Disable All Camera Movement", false, "Disable movement for external control or testing.");
+         ExportLinearColorSpace = CreatePhotoModeSetting(SettingCategory.Experimental, "Record linear color space", false, "When recording a RAW screen-capture should the exported images use linear or sRGB color space.");
+         EnableReplayBuffer = CreatePhotoModeSetting(SettingCategory.Experimental, "Enable Replay buffer", false, "It's a replay buffer");
+         ReplayBufferDuration = CreatePhotoModeSetting(SettingCategory.Experimental, "Replay Buffer Duration", 1f, "Number of seconds to record.");
+         ReplayBufferFramerate = CreatePhotoModeSetting(SettingCategory.Experimental, "Replay Buffer Framerate", 60f, "Rate at which to save frames.", 1f, 240f, 1f);
+         ReplayBufferResolutionScale = CreatePhotoModeSetting(SettingCategory.Experimental, "Replay Buffer Resolution Scale", 1f, "The scaling for the screen size. ", 0.1f, 4f, 0.1f);
+      }
+      catch (Exception e) {
+         // TODO ignore errors for new because of serialization issues running outside unity
+         #if DEBUG
+            // ignore risk of options errors when hot reloading
+         #else
+            Logger.Log($"Error adding setting: {e}");
+         #endif
+      }
    }
 
    private PhotoModeSetting<Color> CreatePhotoModeSetting(SettingCategory category, string name, Color defaultValue, string description = "") {
@@ -171,14 +174,14 @@ public class PhotoModeSettings {
    public readonly PhotoModeSetting<float> CameraMinFov;
    public readonly PhotoModeSetting<float> CameraMaxFov;
    public readonly PhotoModeSetting<float> TimeScaleStep;
-		
+
    // smooth cam
    public readonly PhotoModeSetting<bool> SmoothCamera;
    public readonly PhotoModeSetting<float> PanningSmooth;
    public readonly PhotoModeSetting<float> PanningSmoothTime;
    public readonly PhotoModeSetting<float> MaxSmoothRotationSpeed;
    public readonly PhotoModeSetting<float> RotationSmoothDecay;
-	
+
    // dolly
    public readonly PhotoModeSetting<Easing> DollyEasingFunction;
    public readonly PhotoModeSetting<float> DollyCamSpeed;
@@ -186,7 +189,7 @@ public class PhotoModeSettings {
    public readonly PhotoModeSetting<float> NumberOfDollyPoints;
    public readonly PhotoModeSetting<bool> DollyFollowsFocus;
    public readonly PhotoModeSetting<bool> SmoothDolly;
-	
+
    // key bindings
    public readonly PhotoModeSetting<KeyboardShortcut> RaiseCameraKey;
    public readonly PhotoModeSetting<KeyboardShortcut> LowerCameraKey;
@@ -206,7 +209,7 @@ public class PhotoModeSettings {
    // public readonly PhotoModeSetting<KeyboardShortcut> CaptureScreen;
    public readonly PhotoModeSetting<KeyboardShortcut> SaveReplayBuffer;
    public readonly PhotoModeSetting<KeyboardShortcut> DisplayHelpText;
-	
+
    // arc settings
    public readonly PhotoModeSetting<bool> ToggleArcCamera;
    public readonly PhotoModeSetting<bool> SmoothArcCamera;
@@ -231,12 +234,11 @@ public class PhotoModeSettings {
    public readonly PhotoModeSetting<bool> PostProcessVignetteRounded;
    public readonly PhotoModeSetting<bool> BreakBeforeColorGrading;
    public readonly PhotoModeSetting<bool> PostProcessColorGrading;
-	
+
    // other
    public readonly PhotoModeSetting<float> TextFadeTime;
    public readonly PhotoModeSetting<bool> ShowHelp;
    public readonly PhotoModeSetting<bool> ShowDollyPath;
- 
    public readonly PhotoModeSetting<bool> DisableAllMovement;
    public readonly PhotoModeSetting<bool> ExportLinearColorSpace;
    public readonly PhotoModeSetting<string> LutName;
@@ -251,12 +253,12 @@ public abstract class PhotoModeSetting {
       Name = name;
    }
 
-   public abstract void UpdateValue(object obj) ;
+   public abstract void UpdateValue(object obj);
    public abstract void Save();
    public string Name { get; }
 }
 
-public class PhotoModeSetting<T> : PhotoModeSetting{
+public class PhotoModeSetting<T> : PhotoModeSetting {
    public PhotoModeSetting(SettingCategory category, string name, T defaultValue, string description) : base(name) {
       Category = category;
       DefaultValue = defaultValue;
@@ -318,7 +320,7 @@ public class SettingCategory {
    public SettingCategory(string section) {
       Section = section;
    }
-   
+
    public string Section { get; }
    public static SettingCategory General => new("General");
    public static SettingCategory KeyBindings => new("Key Bindings");

--- a/PhotoMode/PhotoModeSettings.cs
+++ b/PhotoMode/PhotoModeSettings.cs
@@ -45,6 +45,7 @@ public class PhotoModeSettings {
       // dolly
       DollyEasingFunction = CreatePhotoModeSetting(SettingCategory.General, "Dolly Easing Function", Easing.Linear, "How the dolly cam transitions between states. In means start slow and end fast, out means start fast and end slow.");
       DollyCamSpeed = CreatePhotoModeSetting(SettingCategory.General, "Dolly Cam Speed", 5f, "Speed at which the dolly cam pans/rotates", 0);
+      DollyFollowRotation = CreatePhotoModeSetting(SettingCategory.General, "Dolly Follows Rotation", true, "If the dolly camera should follow the rotation you set at the checkpoints or only follow the path and let the user control the rotation.");
       NumberOfDollyPoints = CreatePhotoModeSetting(SettingCategory.General, "Dolly Path Smoothing", 50, "How many line segments to break the dolly path into to create a smooth path. Only applies when you have at least 1 checkpoint. The more points you add the slower the dolly will move.", min: 2, max: 5000, increment: 1);
       DollyFollowsFocus = CreatePhotoModeSetting(SettingCategory.General, "Dolly Auto-Focus", false, "If the dolly should follow your focus changes.");
       SmoothDolly = CreatePhotoModeSetting(SettingCategory.General, "Smooth Dolly Cam", true, "If the dolly cam should always be smooth (when adding at least 1 checkpoint). " +
@@ -181,6 +182,7 @@ public class PhotoModeSettings {
    // dolly
    public readonly PhotoModeSetting<Easing> DollyEasingFunction;
    public readonly PhotoModeSetting<float> DollyCamSpeed;
+   public readonly PhotoModeSetting<bool> DollyFollowRotation;
    public readonly PhotoModeSetting<float> NumberOfDollyPoints;
    public readonly PhotoModeSetting<bool> DollyFollowsFocus;
    public readonly PhotoModeSetting<bool> SmoothDolly;

--- a/PhotoMode/ReplayBuffer.cs
+++ b/PhotoMode/ReplayBuffer.cs
@@ -38,11 +38,13 @@ public partial class ReplayBuffer : MonoBehaviour {
    }
 
    private void OnDestroy() {
-      StopCoroutine(_replayBufferCoroutine);
+      if (_replayBufferCoroutine != null) {
+         StopCoroutine(_replayBufferCoroutine);
+      }
 
       lock (_writeLock) {
          try {
-            _replayBuffer.Dispose();
+            _replayBuffer?.Dispose();
          }
          catch (Exception e) {
             // ignore

--- a/PhotoMode/manifest.json
+++ b/PhotoMode/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "PhotoMode",
-  "version_number": "3.0.10",
+  "version_number": "3.0.11",
   "website_url": "https://github.com/riskofresources/photomode",
   "description": "Photo Mode Redux. Installing Risk Of Options is highly recommended.",
   "dependencies": [


### PR DESCRIPTION
Add option for the user to control the camera and the dolly to just follow the set path. The dolly path is now perfectly smooth but the rotation is only smooth if the change in rotation along segments AB and BC in a path ABC are equal. 

Closes #7 